### PR TITLE
dialog.ts center() update

### DIFF
--- a/components/dialog/dialog.ts
+++ b/components/dialog/dialog.ts
@@ -242,8 +242,8 @@ export class Dialog implements AfterViewInit,OnDestroy {
             this.container.style.visibility = 'visible';
         }
         let viewport = this.domHandler.getViewport();
-        let x = Math.max((viewport.width - elementWidth) / 2, 0);
-        let y = Math.max((viewport.height - elementHeight) / 2, 0);
+        let x = Math.max(Math.floor((viewport.width - elementWidth) / 2), 0);
+        let y = Math.max(Math.floor((viewport.height - elementHeight) / 2), 0);
 
         this.container.style.left = x + 'px';
         this.container.style.top = y + 'px';


### PR DESCRIPTION
In some cases, when after calculating x or y is not an integer value, it causes the call to be looped.
Referenced with #5387

###Defect Fixes
Use Math.floor() to calculate x and y values
